### PR TITLE
Fix navigation links to internal pages

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -8,26 +8,29 @@
 #      Markdown formatted page while the second is generated using JSON.
 
 main:
+  - title: "Academic"
+    url: /academic/
+
   - title: "Publications"
     url: /publications/
 
   - title: "Talks"
-    url: /talks/    
+    url: /talks/
 
   - title: "Teaching"
-    url: /teaching/    
-    
+    url: /teaching/
+
   - title: "Portfolio"
     url: /portfolio/
-        
+
   - title: "Blog Posts"
-    url: /year-archive/
-    
+    url: /blog/
+
   - title: "CV"
     url: /cv/
-    
+
   # - title: "CV"
   #   url: /cv-json/
-    
+
   - title: "Guide"
-    url: /markdown/
+    url: /guide/

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -1,19 +1,19 @@
-{% include base_path %}
-
 <div class="masthead">
   <div class="masthead__inner-wrap">
     <div class="masthead__menu">
       <nav id="site-nav" class="greedy-nav">
         <button><div class="navicon"></div></button>
         <ul class="visible-links">
-          <li class="masthead__menu-item masthead__menu-item--lg persist"><a href="{{ base_path }}/">{{ site.title }}</a></li>
+          {% capture baseurl %}{{ site.baseurl | default: '' }}{% endcapture %}
+          <li class="masthead__menu-item masthead__menu-item--lg persist"><a href="{{ baseurl }}/">{{ site.title }}</a></li>
           {% for link in site.data.navigation.main %}
-            {% if link.url contains 'http' %}
-              {% assign domain = '' %}
+            {% assign link_url = link.url | default: '/' %}
+            {% if link_url contains '://' %}
+              {% assign resolved_url = link_url %}
             {% else %}
-              {% assign domain = base_path %}
+              {% assign resolved_url = baseurl | append: link_url %}
             {% endif %}
-            <li class="masthead__menu-item"><a href="{{ domain }}{{ link.url }}">{{ link.title }}</a></li>
+            <li class="masthead__menu-item"><a href="{{ resolved_url }}">{{ link.title }}</a></li>
           {% endfor %}
           <li id="theme-toggle" class="masthead__menu-item persist tail">
             <a role="button" aria-labelledby="theme-icon"><i id="theme-icon" class="fa-solid fa-sun" aria-hidden="true" title="toggle theme"></i></a>

--- a/_includes/nav_list
+++ b/_includes/nav_list
@@ -1,5 +1,5 @@
-{% include base_path %}
 {% assign navigation = site.data.navigation[include.nav] %}
+{% capture baseurl %}{{ site.baseurl | default: '' }}{% endcapture %}
 
 <nav class="nav__list">
   {% if page.sidebar.title %}<header><h4 class="nav__title" style="padding: 0;">{{ page.sidebar.title }}</h4></header>{% endif %}
@@ -7,14 +7,14 @@
     {% for nav in navigation %}
       <li>
         {% if nav.url %}
-          {% comment %}internal/external URL check{% endcomment %}
-          {% if nav.url contains "://" %}
-            {% assign domain = "" %}
+          {% assign nav_url = nav.url %}
+          {% if nav_url contains "://" %}
+            {% assign resolved_nav_url = nav_url %}
           {% else %}
-            {% assign domain = base_path %}
+            {% assign resolved_nav_url = baseurl | append: nav_url %}
           {% endif %}
 
-          <a href="{{ domain }}{{ nav.url }}"><span class="nav__sub-title">{{ nav.title }}</span></a>
+          <a href="{{ resolved_nav_url }}"><span class="nav__sub-title">{{ nav.title }}</span></a>
         {% else %}
           <span class="nav__sub-title">{{ nav.title }}</span>
         {% endif %}
@@ -22,13 +22,6 @@
         {% if nav.children != null %}
         <ul>
           {% for child in nav.children %}
-            {% comment %}internal/external URL check{% endcomment %}
-            {% if child.url contains "://" %}
-              {% assign domain = "" %}
-            {% else %}
-              {% assign domain = base_path %}
-            {% endif %}
-
             {% comment %}set "active" class on current page{% endcomment %}
             {% if child.url == page.url %}
               {% assign active = "active" %}
@@ -36,7 +29,14 @@
               {% assign active = "" %}
             {% endif %}
 
-            <li><a href="{{ domain }}{{ child.url }}" class="{{ active }}">{{ child.title }}</a></li>
+            {% assign child_url = child.url %}
+            {% if child_url contains "://" %}
+              {% assign resolved_child_url = child_url %}
+            {% else %}
+              {% assign resolved_child_url = baseurl | append: child_url %}
+            {% endif %}
+
+            <li><a href="{{ resolved_child_url }}" class="{{ active }}">{{ child.title }}</a></li>
           {% endfor %}
         </ul>
         {% endif %}

--- a/_pages/academic.md
+++ b/_pages/academic.md
@@ -1,0 +1,9 @@
+---
+layout: single
+title: "Academic"
+permalink: /academic/
+author_profile: true
+---
+
+Welcome to the academic overview page for this site. Use this space to introduce your research interests, current projects, and academic background. You can edit the content in `_pages/academic.md` to tailor the narrative for your readers.
+

--- a/_pages/markdown.md
+++ b/_pages/markdown.md
@@ -1,10 +1,11 @@
 ---
-permalink: /markdown/
-title: "Markdown"
+permalink: /guide/
+title: "Guide"
 author_profile: true
-redirect_from: 
+redirect_from:
   - /md/
   - /markdown.html
+  - /markdown/
 ---
 
 {% include toc %}

--- a/_pages/year-archive.html
+++ b/_pages/year-archive.html
@@ -1,9 +1,10 @@
 ---
 layout: archive
-permalink: /year-archive/
-title: "Blog posts"
+permalink: /blog/
+title: "Blog Posts"
 author_profile: true
 redirect_from:
+  - /year-archive/
   - /wordpress/blog-posts/
 ---
 


### PR DESCRIPTION
## Summary
- update the main navigation data so every item uses an internal path and add an Academic entry
- adjust the masthead and sidebar navigation includes to prepend `site.baseurl` instead of hard-coded domains
- retitle existing guide and blog pages to match the new URLs and add a placeholder academic page

## Testing
- bundle exec jekyll build *(fails: `jekyll` executable is not installed in the bundle)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b36fa160832580bce33734222b45